### PR TITLE
Run using yabs api (Closes #3)

### DIFF
--- a/lua/yabs/defaults/output/quickfix.lua
+++ b/lua/yabs/defaults/output/quickfix.lua
@@ -20,7 +20,9 @@ local function quickfix(cmd, opts)
     vim.fn.setqflist({}, " ", {title = cmd})
 
     opts = opts or {}
-    open_on_run = opts.open_on_run or require("yabs.config").output_types.quickfix.open_on_run
+    open_on_run = opts.open_on_run
+        or require("yabs.config").output_types.quickfix.open_on_run
+        or "auto"
     if open_on_run == "always" then
         vim.cmd("bot copen")
         vim.cmd("wincmd p")

--- a/lua/yabs/init.lua
+++ b/lua/yabs/init.lua
@@ -14,6 +14,10 @@ local M = {
 
 M.Language = require("yabs/language")
 
+function M.run_command(...)
+    require("yabs.util").run_command(...)
+end
+
 function M:setup(opts)
     opts = opts or {}
 

--- a/lua/yabs/language/init.lua
+++ b/lua/yabs/language/init.lua
@@ -30,13 +30,6 @@ function Language:setup(M, args)
     end
 end
 
-local function expand(str)
-    -- Expand % strings and wildcards anywhere in string
-    local split_str = vim.fn.split(str, '\\ze[<%#]')
-    local expanded_str = vim.tbl_map(vim.fn.expand, split_str)
-    return table.concat(expanded_str, '')
-end
-
 function Language:set_output(output)
     -- Set output of this language to output type `output`
     assert(type(output) == "string", "Type of output argument must be string!")
@@ -54,19 +47,13 @@ function Language:build()
         command = self.command
     end
 
-    command = expand(command)
-
-    local output
-    if type(self.output) == "string" then
-        output = output_types[self.output]
-    elseif type(self.output) == "function" then
-        output = self.output
-    end
+    command = require("yabs.util").expand(command)
 
     if self.type == "vim" then
         vim.cmd(command)
     elseif self.type == "shell" then
-        output(command, self.opts)
+        -- output(command, self.opts)
+        require("yabs.util").run_command(command, self.output)
     end
 end
 

--- a/lua/yabs/util/init.lua
+++ b/lua/yabs/util/init.lua
@@ -74,4 +74,22 @@ function M.async_command(cmd, opts)
     return handle, stdin
 end
 
+function M.expand(str)
+    -- Expand % strings and wildcards anywhere in string
+    local split_str = vim.fn.split(str, '\\ze[<%#]')
+    local expanded_str = vim.tbl_map(vim.fn.expand, split_str)
+    return table.concat(expanded_str, '')
+end
+
+function M.run_command(cmd, output, opts)
+    cmd = M.expand(cmd)
+
+    local output_types = require("yabs/defaults").output_types
+    if type(output) == "string" then
+        output = output_types[output]
+    end
+
+    output(cmd, opts)
+end
+
 return M


### PR DESCRIPTION
Add `yabs.run_command(cmd, output, opts)` function as an api to run a command asynchronously using yabs. Arguments are the same as those passed to `yabs.language` in `yabs:setup()`