### PR TITLE
Add tasklist

### DIFF
--- a/lua/yabs/defaults/output/quickfix.lua
+++ b/lua/yabs/defaults/output/quickfix.lua
@@ -1,13 +1,11 @@
 local open_on_run
 
-local open = false
 local function on_read(lines)
     for index, line in ipairs(lines) do
         if index == #lines and line == "" then goto continue end
 
         vim.fn.setqflist({}, "a", {lines = {line}})
-        if not open and open_on_run == "auto" then
-            open = true
+        if open_on_run == "auto" then
             vim.cmd("bot copen")
             vim.cmd("wincmd p")
         end

--- a/lua/yabs/defaults/output/quickfix.lua
+++ b/lua/yabs/defaults/output/quickfix.lua
@@ -18,9 +18,11 @@ local function quickfix(cmd, opts)
     vim.fn.setqflist({}, " ", {title = cmd})
 
     opts = opts or {}
+    local quickfix_ = require("yabs.config").output_types.quickfix or {}
     open_on_run = opts.open_on_run
-        or require("yabs.config").output_types.quickfix.open_on_run
+        or quickfix_.open_on_run
         or "auto"
+
     if open_on_run == "always" then
         vim.cmd("bot copen")
         vim.cmd("wincmd p")

--- a/lua/yabs/init.lua
+++ b/lua/yabs/init.lua
@@ -78,6 +78,23 @@ function Yabs:run_task(task)
         self:setup()
     end
 
+    -- If there is an override_language, run its build function and exit
+    if self.override_language and self.override_language:has_task(task) then
+        self.override_language:run_task(task)
+        return
+    end
+
+    local current_language = self:get_current_language()
+    -- If the current filetype has a build command set up, run it
+    if current_language and current_language:has_task(task) then
+        current_language:run_task(task)
+        return
+    end
+    -- Otherwise, if there is a default_language set up, run its build command
+    if self.default_language and self.default_language:has_task(task) then
+        self.default_language:run_task(task)
+        return
+    end
     if self.tasks then
         if self.tasks[task] then
             self.tasks[task]:run()
@@ -85,21 +102,7 @@ function Yabs:run_task(task)
         end
     end
 
-    -- If there is an override_language, run its build function and exit
-    if self.override_language then
-        self.override_language:run_task(task)
-        return
-    end
-
-    local ft = vim.bo.ft
-    local current_language = self.languages[ft]
-    -- If the current filetype has a build command set up, run it
-    if current_language then
-        current_language:run_task(task)
-    -- Otherwise, if there is a default_language set up, run its build command
-    elseif self.default_language then
-        self.default_language:run_task(task)
-    end
+    error("no task named " .. task)
 end
 
 function Yabs:run_default_task()

--- a/lua/yabs/init.lua
+++ b/lua/yabs/init.lua
@@ -65,7 +65,7 @@ function Yabs:run_task(task)
 
     -- If there is an override_language, run its build function and exit
     if self.override_language then
-        self.override_language:build()
+        self.override_language:run_task(task)
         return
     end
 
@@ -73,10 +73,41 @@ function Yabs:run_task(task)
     local current_language = self.languages[ft]
     -- If the current filetype has a build command set up, run it
     if current_language then
-        current_language:build()
+        current_language:run_task(task)
     -- Otherwise, if there is a default_language set up, run its build command
     elseif self.default_language then
-        self.default_language:build()
+        self.default_language:run_task(task)
+    end
+end
+
+function Yabs:run_default_task()
+    -- If we haven't loaded the .yabs config file yet, load it (if it doesn't
+    -- exist, this will fail silently)
+    if not self.did_config then
+        self:load_config_file()
+    end
+    -- If we haven't run the setup function yet, run it
+    if not self.did_setup then
+        self:setup()
+    end
+
+    -- If there is an override_language, run its build function and exit
+    if self.override_language then
+        -- self.override_language:build()
+        self.override_language:run_default_task()
+        return
+    end
+
+    local ft = vim.bo.ft
+    local current_language = self.languages[ft]
+    -- If the current filetype has a build command set up, run it
+    if current_language then
+        -- current_language:build()
+        current_language:run_default_task()
+    -- Otherwise, if there is a default_language set up, run its build command
+    elseif self.default_language then
+        -- self.default_language:build()
+        self.default_language:run_default_task()
     end
 end
 

--- a/lua/yabs/init.lua
+++ b/lua/yabs/init.lua
@@ -72,16 +72,16 @@ function Yabs:add_task(name, args)
     task:setup(self)
 end
 
-function Yabs:get_tasks_current_language()
+function Yabs:get_current_language_tasks()
     return self:get_current_language().tasks
 end
 
-function Yabs:get_tasks_global()
+function Yabs:get_global_tasks()
     return self.tasks
 end
 
 function Yabs:get_tasks()
-    local current_tasks, global_tasks = self:get_tasks_current_language(), self:get_tasks_global()
+    local current_tasks, global_tasks = self:get_current_language_tasks(), self:get_global_tasks()
     local tasks = vim.tbl_extend("keep", current_tasks, global_tasks)
     return tasks
 end

--- a/lua/yabs/init.lua
+++ b/lua/yabs/init.lua
@@ -3,22 +3,23 @@ vim.cmd("au!")
 vim.cmd("au BufRead,BufNewFile .yabs set ft=lua")
 vim.cmd("augroup end")
 
-local M = {
+local Yabs = {
     default_output = nil,
     languages = {},
+    tasks = {},
     default_language = nil,
     override_language = nil,
     did_config = false,
     did_setup = false
 }
 
-M.Language = require("yabs/language")
+Yabs.Language = require("yabs/language")
 
-function M.run_command(...)
+function Yabs.run_command(...)
     require("yabs.util").run_command(...)
 end
 
-function M:setup(opts)
+function Yabs:setup(opts)
     opts = opts or {}
 
     require("yabs.config").output_types = opts.output_types or {}
@@ -41,17 +42,17 @@ function M:setup(opts)
     self.did_setup = true
 end
 
-function M:add_language(name, args)
+function Yabs:add_language(name, args)
     -- Creat a new language with `args` and call setup on it
     args.name = name
-    local language = M.Language:new(args)
+    local language = Yabs.Language:new(args)
     language:setup(self, {
         override = args.override,
         default = args.default
     })
 end
 
-function M:build()
+function Yabs:run_task(task)
     -- If we haven't loaded the .yabs config file yet, load it (if it doesn't
     -- exist, this will fail silently)
     if not self.did_config then
@@ -85,7 +86,7 @@ local function file_exists(file)
     return f ~= nil
 end
 
-function M:load_config_file()
+function Yabs:load_config_file()
     if file_exists(".yabs") then
         vim.cmd("luafile .yabs")
         self.did_config = true
@@ -96,4 +97,4 @@ function M:load_config_file()
     end
 end
 
-return M
+return Yabs

--- a/lua/yabs/init.lua
+++ b/lua/yabs/init.lua
@@ -61,10 +61,29 @@ function Yabs:add_language(name, args)
     })
 end
 
+function Yabs:get_current_language()
+    local ft = vim.bo.ft
+    return self.languages[ft]
+end
+
 function Yabs:add_task(name, args)
     args.name = name
     local task = Task:new(args)
     task:setup(self)
+end
+
+function Yabs:get_tasks_current_language()
+    return self:get_current_language().tasks
+end
+
+function Yabs:get_tasks_global()
+    return self.tasks
+end
+
+function Yabs:get_tasks()
+    local current_tasks, global_tasks = self:get_tasks_current_language(), self:get_tasks_global()
+    local tasks = vim.tbl_extend("keep", current_tasks, global_tasks)
+    return tasks
 end
 
 function Yabs:run_task(task)
@@ -123,8 +142,7 @@ function Yabs:run_default_task()
         return
     end
 
-    local ft = vim.bo.ft
-    local current_language = self.languages[ft]
+    local current_language = self:get_current_language()
     -- If the current filetype has a build command set up, run it
     if current_language then
         -- current_language:build()

--- a/lua/yabs/language/init.lua
+++ b/lua/yabs/language/init.lua
@@ -19,22 +19,22 @@ function Language:new(args)
     return setmetatable(state, self)
 end
 
-function Language:setup(M, args)
-    if not self.output then self.output = M.default_output end
-    if not self.type then self.type = M.default_type end
+function Language:setup(parent, args)
+    if not self.output then self.output = parent.default_output end
+    if not self.type then self.type = parent.default_type end
 
     for task, options in pairs(self.tasks) do
         self:add_task(task, options)
     end
 
-    M.languages[self.name] = self
+    parent.languages[self.name] = self
 
     if args then
         if args.default == true then
-            M.default_language = self
+            parent.default_language = self
         end
         if args.override == true then
-            M.override_language = self
+            parent.override_language = self
         end
     end
 end

--- a/lua/yabs/language/init.lua
+++ b/lua/yabs/language/init.lua
@@ -53,8 +53,13 @@ function Language:set_output(output)
     return output
 end
 
+function Language:has_task(task)
+    return self.tasks[task] ~= nil
+end
+
 function Language:run_task(task)
     -- self.tasks[task]:run()
+    assert(self:has_task(task), "no task named " .. task .. " for language " .. self.name)
     if type(task) == "string" then
         self.tasks[task]:run()
     elseif type(task) == "table" then

--- a/lua/yabs/task/init.lua
+++ b/lua/yabs/task/init.lua
@@ -1,0 +1,42 @@
+local Task = {}
+
+function Task:new(args)
+    local state = {
+        name = args.name,
+        command = args.command,
+        type = args.type,
+        output = args.output,
+        opts = args.opts
+    }
+
+    self.__index = self
+    return setmetatable(state, self)
+end
+
+function Task:setup(M)
+    if not self.output then self.output = M.output end
+    if not self.type then self.type = M.type end
+
+    M.tasks[self.name] = self
+end
+
+function Task:run()
+    local command
+    if type(self.command) == "function" then
+        -- If `self.command` is a function, command is its return value
+        command = self.command()
+    else
+        command = self.command
+    end
+
+    command = require("yabs.util").expand(command)
+
+    if self.type == "vim" then
+        vim.cmd(command)
+    elseif self.type == "shell" then
+        -- output(command, self.opts)
+        require("yabs.util").run_command(command, self.output)
+    end
+end
+
+return Task

--- a/lua/yabs/task/init.lua
+++ b/lua/yabs/task/init.lua
@@ -13,11 +13,11 @@ function Task:new(args)
     return setmetatable(state, self)
 end
 
-function Task:setup(M)
-    if not self.output then self.output = M.output end
-    if not self.type then self.type = M.type end
+function Task:setup(parent)
+    if not self.output then self.output = parent.output end
+    if not self.type then self.type = parent.type end
 
-    M.tasks[self.name] = self
+    parent.tasks[self.name] = self
 end
 
 function Task:run()


### PR DESCRIPTION
See #5 tasklist section.

Adds a list of tasks for each filetype so that each filetype can have more than one command tied to it (for example, one to compile, one to run, and one for tests, etc.)

Still todo:
Add global tasks for use in .yabs file.