### PR TITLE
Telescope integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,10 @@ The first time you run `yabs:build()`, yabs will look for a file named .yabs in
 the current working directory. If found, it will be sourced as a lua file. This
 is useful for project-local configurations.
 
+## Telescope integration
+
+You can execute tasks from Telescope by running `:Telescope yabs tasks` / `:Telescope yabs current_language_tasks` or `:Telescope yabs global_tasks`.
+
 ## Advanced configuration
 
 The language.command option in `yabs:setup()` can be a string or a function that returns a string. Specifying a function instead can be useful for more advanced commands.

--- a/lua/telescope/_extensions/yabs.lua
+++ b/lua/telescope/_extensions/yabs.lua
@@ -4,12 +4,13 @@ local pickers = require('telescope.pickers')
 local finders = require('telescope.finders')
 local sorters = require('telescope.sorters')
 local Yabs = require('yabs')
+local scopes = require('yabs.task').scopes
 
-local function select_task(tasks_function, opts)
+local function select_task(opts, scope)
   pickers.new(opts, {
     prompt_title = 'Select a task',
     finder = finders.new_table({
-      results = vim.tbl_values(tasks_function(Yabs)),
+      results = vim.tbl_values(Yabs:get_tasks(scope)),
       entry_maker = function(entry)
         return {
           value = entry.name,
@@ -24,7 +25,7 @@ local function select_task(tasks_function, opts)
         actions.close(prompt_bufnr)
         local entry = actions.get_selected_entry(prompt_bufnr)
         if entry then
-          Yabs:run_task(entry.value, opts)
+          Yabs:run_task(entry.value, scope)
         end
       end
 
@@ -37,15 +38,13 @@ end
 return telescope.register_extension({
   exports = {
     tasks = function(opts)
-      select_task(Yabs.get_tasks, opts)
+      select_task(opts)
     end,
     current_language_tasks = function(opts)
-      opts.current_language = true
-      select_task(Yabs.get_current_language_tasks, opts)
+      select_task(opts, scopes.LOCAL)
     end,
     global_tasks = function(opts)
-      opts.global = true
-      select_task(Yabs.get_global_tasks, opts)
+      select_task(opts, scopes.GLOBAL)
     end,
   },
 })

--- a/lua/telescope/_extensions/yabs.lua
+++ b/lua/telescope/_extensions/yabs.lua
@@ -24,7 +24,7 @@ local function select_task(tasks_function, opts)
         actions.close(prompt_bufnr)
         local entry = actions.get_selected_entry(prompt_bufnr)
         if entry then
-          Yabs:run_task(entry.value)
+          Yabs:run_task(entry.value, opts)
         end
       end
 
@@ -40,9 +40,11 @@ return telescope.register_extension({
       select_task(Yabs.get_tasks, opts)
     end,
     current_language_tasks = function(opts)
+      opts.current_language = true
       select_task(Yabs.get_current_language_tasks, opts)
     end,
     global_tasks = function(opts)
+      opts.global = true
       select_task(Yabs.get_global_tasks, opts)
     end,
   },

--- a/lua/telescope/_extensions/yabs.lua
+++ b/lua/telescope/_extensions/yabs.lua
@@ -38,7 +38,7 @@ end
 return telescope.register_extension({
   exports = {
     tasks = function(opts)
-      select_task(opts)
+      select_task(opts, scopes.ALL)
     end,
     current_language_tasks = function(opts)
       select_task(opts, scopes.LOCAL)

--- a/lua/telescope/_extensions/yabs.lua
+++ b/lua/telescope/_extensions/yabs.lua
@@ -3,10 +3,13 @@ local actions = require('telescope.actions')
 local pickers = require('telescope.pickers')
 local finders = require('telescope.finders')
 local sorters = require('telescope.sorters')
+local themes = require('telescope.themes')
 local Yabs = require('yabs')
 local scopes = require('yabs.task').scopes
 
 local function select_task(opts, scope)
+  opts = themes.get_dropdown(opts)
+
   pickers.new(opts, {
     prompt_title = 'Select a task',
     finder = finders.new_table({

--- a/lua/telescope/_extensions/yabs.lua
+++ b/lua/telescope/_extensions/yabs.lua
@@ -1,0 +1,49 @@
+local telescope = require('telescope')
+local actions = require('telescope.actions')
+local pickers = require('telescope.pickers')
+local finders = require('telescope.finders')
+local sorters = require('telescope.sorters')
+local Yabs = require('yabs')
+
+local function select_task(tasks_function, opts)
+  pickers.new(opts, {
+    prompt_title = 'Select a session',
+    finder = finders.new_table({
+      results = vim.tbl_values(tasks_function(Yabs)),
+      entry_maker = function(entry)
+        return {
+          value = entry.name,
+          display = string.format('%s: %s', entry.name, entry.command),
+          ordinal = entry.name .. entry.command,
+        }
+      end,
+    }),
+    sorter = sorters.get_fzy_sorter(),
+    attach_mappings = function(prompt_bufnr)
+      local source_session = function()
+        actions.close(prompt_bufnr)
+        local entry = actions.get_selected_entry(prompt_bufnr)
+        if entry then
+          Yabs:run_task(entry.value)
+        end
+      end
+
+      actions.select_default:replace(source_session)
+      return true
+    end,
+  }):find()
+end
+
+return telescope.register_extension({
+  exports = {
+    tasks = function(opts)
+      select_task(Yabs.get_tasks, opts)
+    end,
+    current_language_tasks = function(opts)
+      select_task(Yabs.get_current_language_tasks, opts)
+    end,
+    global_tasks = function(opts)
+      select_task(Yabs.get_global_tasks, opts)
+    end,
+  },
+})

--- a/lua/yabs/init.lua
+++ b/lua/yabs/init.lua
@@ -73,6 +73,7 @@ function Yabs:add_task(name, args)
 end
 
 function Yabs:get_current_language_tasks()
+    if not self.did_setup then return {} end
     return self:get_current_language().tasks
 end
 

--- a/lua/yabs/init.lua
+++ b/lua/yabs/init.lua
@@ -83,16 +83,15 @@ function Yabs:get_global_tasks()
 end
 
 function Yabs:get_tasks(scope)
-    local local_tasks, global_tasks = self:get_current_language_tasks(), self:get_global_tasks()
     if scope then
         if scope == scopes.GLOBAL then
-            return local_tasks
+            return self:get_global_tasks()
         end
         if scope == scopes.LOCAL then
-            return global_tasks
+            return self:get_current_language_tasks()
         end
     end
-    local tasks = vim.tbl_extend("keep", local_tasks, global_tasks)
+    return vim.tbl_extend("keep", self:get_current_language_tasks(), self:get_global_tasks())
     return tasks
 end
 

--- a/lua/yabs/init.lua
+++ b/lua/yabs/init.lua
@@ -83,16 +83,17 @@ function Yabs:get_global_tasks()
 end
 
 function Yabs:get_tasks(scope)
-    if scope then
-        if scope == scopes.GLOBAL then
-            return self:get_global_tasks()
-        end
-        if scope == scopes.LOCAL then
-            return self:get_current_language_tasks()
-        end
+    if not scope then scope = scopes.ALL end
+
+    if scope == scopes.GLOBAL then
+        return self:get_global_tasks()
     end
+    if scope == scopes.LOCAL then
+        return self:get_current_language_tasks()
+    end
+
+    assert(scope == scopes.ALL, "unsupported scope: " .. scope)
     return vim.tbl_extend("keep", self:get_current_language_tasks(), self:get_global_tasks())
-    return tasks
 end
 
 function Yabs:run_global_task(task)
@@ -114,6 +115,8 @@ function Yabs:run_task(task, scope)
         self:setup()
     end
 
+    if not scope then scope = scopes.ALL end
+
     if scope == scopes.GLOBAL then
         self:run_global_task(task)
         return
@@ -125,6 +128,7 @@ function Yabs:run_task(task, scope)
         end
         return
     end
+    assert(scope == scopes.ALL, "unsupported scope: " .. scope)
 
     -- If there is an override_language, run its build function and exit
     if self.override_language and self.override_language:has_task(task) then

--- a/lua/yabs/language/init.lua
+++ b/lua/yabs/language/init.lua
@@ -8,7 +8,7 @@ function Language:new(args)
     local state = {
         name = args.name,
         -- command = args.command,
-        tasks = args.tasks,
+        tasks = args.tasks or {},
         default_task = args.default_task,
         type = args.type,
         output = args.output,

--- a/lua/yabs/task/init.lua
+++ b/lua/yabs/task/init.lua
@@ -1,7 +1,8 @@
 local Task = {
     scopes = {
         GLOBAL = 1,
-        LOCAL = 2
+        LOCAL = 2,
+        ALL = 3
     }
 }
 

--- a/lua/yabs/task/init.lua
+++ b/lua/yabs/task/init.lua
@@ -1,4 +1,9 @@
-local Task = {}
+local Task = {
+    scopes = {
+        GLOBAL = 1,
+        LOCAL = 2
+    }
+}
 
 function Task:new(args)
     local state = {


### PR DESCRIPTION
I implemented what we discussed in #5.

Should work as expected.
But I found two issues:

1. If you override any global tasks, `get_global_tasks()` still returns overriden tasks. Maybe remove overriden tasks from this list? Or even disallow overrides at all?
2. If there is no tasks, `:lua require("yabs"):get_tasks()` returns the following error: `E5108: Error executing lua ...nfig/nvim/pack/plugins/start/yabs.nvim/lua/yabs/init.lua:76: attempt to index a nil value`