### PR TITLE
Use ftdetect to set .yabs filetype

### DIFF
--- a/ftdetect/yabs.vim
+++ b/ftdetect/yabs.vim
@@ -1,0 +1,1 @@
+autocmd BufNewFile,BufRead .yabs set ft=lua

--- a/lua/yabs/init.lua
+++ b/lua/yabs/init.lua
@@ -1,8 +1,3 @@
-vim.api.nvim_command('augroup yabs')
-vim.api.nvim_command('au!')
-vim.api.nvim_command('au BufRead,BufNewFile .yabs set ft=lua')
-vim.api.nvim_command('augroup end')
-
 local Yabs = {
   default_output = nil,
   default_type = nil,


### PR DESCRIPTION
[ftdetect](https://neovim.io/doc/user/filetype.html) is a preferred way to set filetype. You could check how it done in [Treesitter](https://github.com/nvim-treesitter/nvim-treesitter/tree/master/ftdetect), for example.