### PR TITLE
Use util.notify instead of error

### DIFF
--- a/lua/yabs/init.lua
+++ b/lua/yabs/init.lua
@@ -193,7 +193,7 @@ function Yabs:run_task(task, opts)
     return
   end
 
-  error('yabs: no task named ' .. task)
+  util.notify('No task named ' .. task, vim.log.levels.ERROR)
 end
 
 function Yabs:run_default_task()


### PR DESCRIPTION
When the task is not found, it is better to display a notification about this.
![изображение](https://user-images.githubusercontent.com/22453358/144722697-131ef802-44bb-430e-a681-87b7e1319c5e.png)
