### PR TITLE
Breaking change: refactor using plenary.job

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,12 @@ require('yabs'):setup({
             -- WARNING: this api is experimental and subject to
             -- changes
             require('yabs'):run_task('build', {
-              on_exit = function(Job, exit_code) -- Job here is a plenary.job object
+              -- Job here is a plenary.job object that represents
+              -- the finished task, read more about it here:
+              -- https://github.com/nvim-lua/plenary.nvim/blob/master/lua/plenary/job.lua
+              on_exit = function(Job, exit_code)
+                -- You can omit extra arguments or skip
+                -- some of them using _ for the name
                 if exit_code == 0 then
                   require('yabs').languages.c:run_task('run')
                 end
@@ -159,23 +164,27 @@ subject to change, and is not recommended to be used in normal configurations.
 <summary>Buffer</summary>
 
 ![buffer](./buffer.png)
+
 </details>
 
 <details>
 <summary>Echo</summary>
 
 ![echo](./echo.png)
+
 </details>
 
 <details>
 <summary>Quickfix</summary>
 
 ![quickfix](./quickfix.png)
+
 </details>
 
 <details>
 <summary>Terminal</summary>
 
 ![termina](./terminal.png)
+
 </details>
 <!-- ![screenshot](./screenshot.png) -->

--- a/README.md
+++ b/README.md
@@ -73,10 +73,11 @@ require('yabs'):setup({
             require('yabs'):run_task('build', {
               -- Job here is a plenary.job object that represents
               -- the finished task, read more about it here:
-              -- https://github.com/nvim-lua/plenary.nvim/blob/master/lua/plenary/job.lua
+              -- https://github.com/nvim-lua/plenary.nvim#plenaryjob
               on_exit = function(Job, exit_code)
-                -- You can omit extra arguments or skip
-                -- some of them using _ for the name
+                -- The parameters `Job` and `exit_code` are optional,
+                -- you can omit extra arguments or
+                -- skip some of them using _ for the name
                 if exit_code == 0 then
                   require('yabs').languages.c:run_task('run')
                 end

--- a/README.md
+++ b/README.md
@@ -10,19 +10,21 @@ yabs.nvim adds vscode-like tasks feature to neovim. It allows you to define spec
 
 ## Installation
 
-Packer.nvim:
+[packer.nvim](https://github.com/wbthomason/packer.nvim):
 
 ```lua
-use 'pianocomposer321/yabs.nvim'`
+use {
+  'pianocomposer321/yabs.nvim',
+  requires = { 'nvim-lua/plenary.nvim' }
+}
 ```
 
-vim-plug:
+[vim-plug](https://github.com/junegunn/vim-plug):
 
 ```lua
+Plug 'nvim-lua/plenary.nvim'`
 Plug 'pianocomposer321/yabs.nvim'`
 ```
-
-etc.
 
 ## Setup
 
@@ -69,8 +71,10 @@ require('yabs'):setup({
             -- WARNING: this api is experimental and subject to
             -- changes
             require('yabs'):run_task('build', {
-              on_exit = function()
-                require('yabs').languages.c:run_task('run')
+              on_exit = function(Job, exit_code) -- Job here is a plenary.job object
+                if exit_code == 0 then
+                  require('yabs').languages.c:run_task('run')
+                end
               end,
             })
           end,

--- a/lua/yabs/outputs/buffer.lua
+++ b/lua/yabs/outputs/buffer.lua
@@ -1,3 +1,6 @@
+local utils = require('yabs.utils')
+local Job = require('plenary.job')
+
 local function make_scratch_buffer(height, position)
   if not height then
     height = ''
@@ -18,28 +21,25 @@ local function make_scratch_buffer(height, position)
   return vim.fn.bufnr()
 end
 
-local function append_to_buffer(buffer, lines)
-  vim.api.nvim_buf_set_lines(buffer, -2, -2, false, lines)
-end
-
 local bufnr
 
-local function on_read(lines)
-  lines[#lines] = nil
-  append_to_buffer(bufnr, lines)
+local function on_read(error, data)
+  vim.api.nvim_buf_set_lines(bufnr, -2, -2, false, { error and error or data })
 end
 
 local function buffer(cmd, opts)
   opts = opts or {}
-
   bufnr = make_scratch_buffer(14, 'bot')
 
-  local on_exit = opts.on_exit
-
-  require('yabs.utils').async_command(cmd, {
-    on_exit = on_exit,
-    on_read = vim.schedule_wrap(on_read),
+  local splitted_cmd = utils.split_cmd(cmd)
+  local job = Job:new({
+    command = table.remove(splitted_cmd, 1),
+    args = splitted_cmd,
+    on_exit = opts.on_exit,
+    on_stdout = vim.schedule_wrap(on_read),
+    on_stderr = vim.schedule_wrap(on_read),
   })
+  job:start()
 end
 
 local Output = require('yabs.output')

--- a/lua/yabs/outputs/buffer.lua
+++ b/lua/yabs/outputs/buffer.lua
@@ -23,7 +23,7 @@ end
 
 local bufnr
 
-local function on_read(error, data)
+local function append_to_buffer(error, data)
   vim.api.nvim_buf_set_lines(bufnr, -2, -2, false, { error and error or data })
 end
 
@@ -36,8 +36,8 @@ local function buffer(cmd, opts)
     command = table.remove(splitted_cmd, 1),
     args = splitted_cmd,
     on_exit = opts.on_exit,
-    on_stdout = vim.schedule_wrap(on_read),
-    on_stderr = vim.schedule_wrap(on_read),
+    on_stdout = vim.schedule_wrap(append_to_buffer),
+    on_stderr = vim.schedule_wrap(append_to_buffer),
   })
   job:start()
 end

--- a/lua/yabs/outputs/none.lua
+++ b/lua/yabs/outputs/none.lua
@@ -1,5 +1,13 @@
+local utils = require('yabs.utils')
+local Job = require('plenary.job')
+
 local function none(cmd)
-  require('yabs.utils').async_command(cmd)
+  local splitted_cmd = utils.split_cmd(cmd)
+  local job = Job:new({
+    command = table.remove(splitted_cmd, 1),
+    args = splitted_cmd,
+  })
+  job:start()
 end
 
 local Output = require('yabs.output')

--- a/lua/yabs/outputs/quickfix.lua
+++ b/lua/yabs/outputs/quickfix.lua
@@ -5,7 +5,7 @@ local Job = require('plenary.job')
 local open_on_run
 local dir
 
-local function on_read(error, data)
+local function append_to_quickfix(error, data)
   vim.fn.setqflist({}, 'a', { lines = { error and error or data } })
   if open_on_run == 'auto' then
     vim.api.nvim_command(dir .. ' copen')
@@ -32,8 +32,8 @@ local function quickfix(cmd, opts)
   local job = Job:new({
     command = table.remove(splitted_cmd, 1),
     args = splitted_cmd,
-    on_stdout = vim.schedule_wrap(on_read),
-    on_stderr = vim.schedule_wrap(on_read),
+    on_stdout = vim.schedule_wrap(append_to_quickfix),
+    on_stderr = vim.schedule_wrap(append_to_quickfix),
     on_exit = opts.on_exit,
   })
   job:start()

--- a/lua/yabs/outputs/quickfix.lua
+++ b/lua/yabs/outputs/quickfix.lua
@@ -1,45 +1,42 @@
+local config = require('yabs.config')
+local utils = require('yabs.utils')
+local Job = require('plenary.job')
+
 local open_on_run
 local dir
 
-local function on_read(lines)
-  for index, line in ipairs(lines) do
-    if index == #lines and line == '' then
-      goto continue
-    end
-
-    vim.fn.setqflist({}, 'a', { lines = { line } })
-    if open_on_run == 'auto' then
-      vim.api.nvim_command(dir .. ' copen')
-      vim.api.nvim_command('wincmd p')
-    end
-
-    ::continue::
+local function on_read(error, data)
+  vim.fn.setqflist({}, 'a', { lines = { error and error or data } })
+  if open_on_run == 'auto' then
+    vim.api.nvim_command(dir .. ' copen')
+    vim.api.nvim_command('wincmd p')
   end
 end
 
 local function quickfix(cmd, opts)
-  vim.fn.setqflist({}, ' ', { title = cmd })
-
   opts = opts or {}
 
-  local config = require('yabs.config')
+  vim.fn.setqflist({}, ' ', { title = cmd })
+
   local quickfix_config = config.opts.output_types.quickfix
 
   open_on_run = opts.open_on_run or quickfix_config.open_on_run or 'auto'
-
   dir = opts.dir or quickfix_config.dir or 'bot'
-
-  local on_exit = opts.on_exit
 
   if open_on_run == 'always' then
     vim.api.nvim_command(dir .. ' copen')
     vim.api.nvim_command('wincmd p')
   end
 
-  require('yabs.utils').async_command(cmd, {
-    on_read = on_read,
-    on_exit = on_exit,
+  local splitted_cmd = utils.split_cmd(cmd)
+  local job = Job:new({
+    command = table.remove(splitted_cmd, 1),
+    args = splitted_cmd,
+    on_stdout = vim.schedule_wrap(on_read),
+    on_stderr = vim.schedule_wrap(on_read),
+    on_exit = opts.on_exit,
   })
+  job:start()
 end
 
 local Output = require('yabs.output')

--- a/lua/yabs/utils.lua
+++ b/lua/yabs/utils.lua
@@ -1,110 +1,5 @@
 local M = {}
 
-local function on_exit(stdio, handle, on_exit_)
-  local stdin, stdout, stderr = unpack(stdio)
-
-  stdout:read_stop()
-  stderr:read_stop()
-
-  stdout:close()
-  stderr:close()
-
-  if stdin then
-    stdin:shutdown()
-  end
-
-  handle:close()
-
-  if on_exit_ then
-    on_exit_()
-  end
-end
-
-local function on_read(err, data, on_read_, split_lines)
-  assert(not err, err)
-
-  if not data then
-    return
-  end
-
-  if split_lines then
-    data = vim.split(data, '\n')
-  end
-
-  if on_read_ then
-    on_read_(data)
-  end
-end
-
-function M.async_command(cmd, opts)
-  local default_opts = {
-    use_stdin = false,
-    dont_schedule = false,
-    split_lines = true,
-    on_exit = function() end,
-    on_read = function() end,
-  }
-
-  opts = vim.tbl_extend('keep', opts, default_opts)
-
-  local args
-
-  local shell = opts.shell or vim.o.shell
-  local shellcmdflag = opts.shellcmdflag or vim.o.shellcmdflag
-
-  local useshell = opts.useshell or true
-  if useshell then
-    args = { shellcmdflag, cmd }
-    cmd = shell
-  else
-    args = vim.split(cmd, ' ')
-    cmd = table.remove(args, 1)
-  end
-
-  local loop = vim.loop
-
-  local stdout = loop.new_pipe()
-  local stderr = loop.new_pipe()
-  local stdin
-  if opts.use_stdin then
-    stdin = loop.new_pipe()
-  end
-
-  local stdio = { stdin, stdout, stderr }
-
-  local handle
-  if opts.dont_schedule then
-    handle = loop.spawn(cmd, {
-      stdio = stdio,
-      args = args,
-    }, function()
-      on_exit(stdio, handle, opts.on_exit)
-    end)
-  else
-    handle = loop.spawn(
-      cmd,
-      {
-        stdio = stdio,
-        args = args,
-      },
-      vim.schedule_wrap(function()
-        on_exit(stdio, handle, opts.on_exit)
-      end)
-    )
-  end
-
-  local l_on_read = function(err, data)
-    on_read(err, data, opts.on_read, opts.split_lines)
-  end
-  if not opts.dont_schedule then
-    l_on_read = vim.schedule_wrap(l_on_read)
-  end
-  loop.read_start(stdout, l_on_read)
-  loop.read_start(stderr, l_on_read)
-
-  return handle, stdin
-end
-
 function M.expand(str)
   -- Expand % strings and wildcards anywhere in string
   local split_str = vim.split(str, ' ')
@@ -139,6 +34,21 @@ end
 
 function M.notify(msg, log_level)
   vim.notify(msg, log_level, { title = 'Yabs' })
+end
+
+function M.split_cmd(cmd)
+  if not cmd then
+    return {}
+  end
+
+  -- Split on spaces unless "in quotes"
+  local splitted_cmd = vim.fn.split(cmd, [[\s\%(\%([^'"]*\(['"]\)[^'"]*\1\)*[^'"]*$\)\@=]])
+
+  -- Remove quotes
+  for i, arg in ipairs(splitted_cmd) do
+    splitted_cmd[i] = arg:gsub('"', ''):gsub("'", '')
+  end
+  return splitted_cmd
 end
 
 return M


### PR DESCRIPTION
* Now plenary is required.
* Respect quotes in command.
* `on_exit` accepts plenary.job and exit code to control the behavior.

Fixes #25.