### PR TITLE
Add more clear description about .yabs

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,11 +135,34 @@ yabs:run_default_task()
 yabs.run_command('echo hello, world', 'quickfix', { open_on_run = 'always' })
 ```
 
-### ".yabs" files
+### `.yabs` files
 
-The first time you execute `yabs:run_task()`, yabs will look for a file named .yabs in
-the current working directory. If found, it will be sourced as a lua file. This
-is useful for project-local configurations.
+You can create project-local configurations by creating `.yabs` file
+in the project working directory. It will be sourced as a lua file the
+first time you execute `yabs:run_task()`. The file should return a
+table with additional task that will be append to your global
+configuration. The syntax is the same as for [setup()](#setup):
+
+```lua
+return {
+  languages = {
+    python = {
+      tasks = {
+        run = {
+          command = 'python %',
+          type = 'quickfix',
+        },
+      },
+    },
+  },
+  tasks = {
+    build = {
+      command = 'cargo build',
+      output = 'consolation',
+    },
+  }
+}
+```
 
 ## Telescope integration
 

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ yabs.run_command('echo hello, world', 'quickfix', { open_on_run = 'always' })
 You can create project-local configurations by creating `.yabs` file
 in the project working directory. It will be sourced as a lua file the
 first time you execute `yabs:run_task()`. The file should return a
-table with additional task that will be append to your global
+table with additional task that will extend your main
 configuration. The syntax is the same as for [setup()](#setup):
 
 ```lua
@@ -150,7 +150,7 @@ return {
       tasks = {
         run = {
           command = 'python %',
-          type = 'quickfix',
+          output = 'quickfix',
         },
       },
     },

--- a/README.md
+++ b/README.md
@@ -140,8 +140,10 @@ yabs.run_command('echo hello, world', 'quickfix', { open_on_run = 'always' })
 You can create project-local configurations by creating `.yabs` file
 in the project working directory. It will be sourced as a lua file the
 first time you execute `yabs:run_task()`. The file should return a
-table with additional task that will extend your main
-configuration. The syntax is the same as for [setup()](#setup):
+table with additional task that will extend your main configuration,
+overriding any values already defined there.
+
+The syntax is the same as for [setup()](#setup):
 
 ```lua
 return {


### PR DESCRIPTION
In this PR I have added a more detailed description and example for `.yabs`.

Before I contributed the first time, I thought that inside `.yabs`, I need to call `setup()` because it worked :D But it's better to just return a table for sure.