### PR TITLE
Verify that .yabs files are trusted before executing

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,14 +189,14 @@ For this reason whenever a new `.yabs` file is found or an old one changes
 file. If you answer `yes` then no further prompts will occur until this file's
 content changes. Answering `no` will mark the file as untrusted and it will
 not be loaded now, nor in the future. No answer will ignore the file for this
-session, but will ask again later.
-
-To reset information about file being trusted/untrusted use the command
-`:YabsResetTrust PATH_TO_YABS_FILE`. This will make Yabs prompt for trust
-the next time when the file is loaded.
+session, but will ask again later. `.yabs` files edited from Neovim will
+automatically be trusted (via `BufWritePost`).
 
 The information about trusted files is stored in a database that is saved
 under Neovim's user data directory (output of `:echo stdpath('data')`).
+To trust/untrust a file use `:YabsTrust FILE`/`:YabsTrust! FILE`. To reset
+information about given file use `:YabsTrustReset FILE` or `:YabsTrustResetAll`
+to reset the whole database.
 
 ## Telescope integration
 

--- a/README.md
+++ b/README.md
@@ -116,6 +116,9 @@ require('yabs'):setup({
       },
     },
   },
+  -- Setting this to true disables .yabs files verification, please read the
+  -- section about .yabs files first as this is a potential security risk.
+  exec_untrusted = false,
 })
 ```
 
@@ -142,10 +145,10 @@ yabs.run_command('echo hello, world', 'quickfix', { open_on_run = 'always' })
 ### `.yabs` files
 
 You can create project-local configurations by creating `.yabs` file
-in the project working directory. It will be sourced as a lua file the
-first time you execute `yabs:run_task()`. The file should return a
-table with additional task that will extend your main configuration,
-overriding any values already defined there.
+in the project working directory. It will be sourced as a lua file
+(see [security](#.yabs-files-security)) first time you execute `yabs:run_task()`.
+The file should return a table with additional task that will extend your main
+configuration, overriding any values already defined there.
 
 The syntax is the same as for [setup()](#setup):
 
@@ -169,6 +172,31 @@ return {
   }
 }
 ```
+
+#### `.yabs` files security
+
+Running arbitrary Lua code is a security risk that may lead to execution
+of malicous code, consider the following scenario:
+
+> Imagine you download a git repo and want to open some file in Neovim,
+> but you haven't examined the `.yabs` file located inside the repo. This
+> file would be executed silently without your knowledge and, because it's
+> just a regular Lua file, it could do anything including accessing your
+> filesystem, deleting files, etc.
+
+For this reason whenever a new `.yabs` file is found or an old one changes
+(which is verifed via SHA256 checksums) you will be prompted to trust this
+file. If you answer `yes` then no further prompts will occur until this file's
+content changes. Answering `no` will mark the file as untrusted and it will
+not be loaded now, nor in the future. No answer will ignore the file for this
+session, but will ask again later.
+
+To reset information about file being trusted/untrusted use the command
+`:YabsResetTrust PATH_TO_YABS_FILE`. This will make Yabs prompt for trust
+the next time when the file is loaded.
+
+The information about trusted files is stored in a database that is saved
+under Neovim's user data directory (output of `:echo stdpath('data')`).
 
 ## Telescope integration
 

--- a/ftdetect/yabs.vim
+++ b/ftdetect/yabs.vim
@@ -1,1 +1,2 @@
-autocmd BufNewFile,BufRead .yabs set ft=lua
+autocmd BufNewFile,BufRead .yabs setlocal ft=lua
+autocmd BufWritePost .yabs YabsTrust <afile>

--- a/lua/telescope/_extensions/yabs.lua
+++ b/lua/telescope/_extensions/yabs.lua
@@ -8,11 +8,11 @@ local themes = require('telescope.themes')
 local Yabs = require('yabs')
 local scopes = require('yabs.task').scopes
 
-if not Yabs.did_conf then
-  Yabs:load_config_file()
-end
-
 local function select_task(opts, scope)
+  if not Yabs.did_conf then
+    Yabs:load_config_file()
+  end
+
   opts = themes.get_dropdown(opts)
 
   local tasks = Yabs:get_tasks(scope)

--- a/lua/yabs/config.lua
+++ b/lua/yabs/config.lua
@@ -10,6 +10,7 @@ local config = {
     type = 'shell',
     output = 'echo',
   },
+  exec_untrusted = false,
 }
 setmetatable(config, { __index = config.defaults })
 

--- a/lua/yabs/db.lua
+++ b/lua/yabs/db.lua
@@ -1,0 +1,60 @@
+local Path = require('plenary.path')
+
+local defaults = {
+  trusted = {},
+  untrusted = {},
+}
+
+local DataBase = {}
+DataBase.__index = DataBase
+
+function DataBase:path()
+  return Path:new(vim.fn.stdpath('data')) / 'yabs.json'
+end
+
+function DataBase:load()
+  local path = self:path()
+  local ok, data = pcall(path.read, path)
+  local tbl = ok and vim.json.decode(data) or {}
+  return setmetatable({
+    db = vim.tbl_extend('force', defaults, tbl),
+  }, self)
+end
+
+function DataBase:save()
+  self:path():write(vim.json.encode(self.db), 'w')
+end
+
+function DataBase:is_trusted(path)
+  local fname = path:absolute()
+
+  -- Check if we already have db entry for this one
+  if vim.tbl_contains(self.db.untrusted, fname) then
+    return false
+  elseif vim.tbl_contains(self.db.trusted, fname) then
+    return true
+  end
+
+  -- If not then ask user what to do
+  -- TODO: use vim.ui.input; requires async-ifying the api
+  local answer = vim.fn.input {
+    prompt = string.format('Found .yabs file:\n%s\nAdd to trusted? [y/n]: ', fname),
+  }
+
+  if vim.tbl_contains({'y', 'yes'}, answer:lower()) then
+    vim.notify('\nAdding to trusted files: ' .. fname)
+    table.insert(self.db.trusted, fname)
+    self:save()
+    return true
+  elseif vim.tbl_contains({'n', 'no'}, answer:lower()) then
+    vim.notify('\nAdding to untrusted files: ' .. fname)
+    table.insert(self.db.untrusted, fname)
+    self:save()
+    return false
+  else
+    vim.notify('\nIgnoring file: ' .. fname)
+    return false
+  end
+end
+
+return DataBase

--- a/lua/yabs/db.lua
+++ b/lua/yabs/db.lua
@@ -44,8 +44,19 @@ function DataBase:compute_checksum(fname)
   return vim.fn.sha256(data)
 end
 
+-- Convert a file path to filename used as key in the database
+function DataBase:to_fname(path)
+  return Path:new(path):absolute()
+end
+
+-- Remove information about a file from the database
+function DataBase:reset(path)
+  self.db.trusted[self:to_fname(path)] = nil
+  self.db.untrusted[self:to_fname(path)] = nil
+end
+
 function DataBase:is_trusted(path)
-  local fname = path:absolute()
+  local fname = self:to_fname(path)
 
   -- Check if we already have db entry for this one
   -- Untrusted files should just be ignored

--- a/lua/yabs/db.lua
+++ b/lua/yabs/db.lua
@@ -36,6 +36,7 @@ end
 -- Save the database to disk
 function DataBase:save()
   self:path():write(vim.json.encode(self.db), 'w')
+  return self
 end
 
 function DataBase:compute_checksum(fname)
@@ -53,6 +54,30 @@ end
 function DataBase:reset(path)
   self.db.trusted[self:to_fname(path)] = nil
   self.db.untrusted[self:to_fname(path)] = nil
+  return self
+end
+
+-- Remove all entries
+function DataBase:reset_all()
+  self.db = vim.tbl_extend('force', defaults, {})
+  return self
+end
+
+-- Make given file (un-)trusted
+-- If not specified trusted=true and checksum is auto-generated
+function DataBase:trust(path, trusted, checksum)
+  if trusted == nil then
+    trusted = true
+  end
+  checksum = checksum or self:compute_checksum(path)
+  if trusted then
+    self.db.trusted[self:to_fname(path)] = checksum
+    self.db.untrusted[self:to_fname(path)] = nil
+  else
+    self.db.trusted[self:to_fname(path)] = nil
+    self.db.untrusted[self:to_fname(path)] = checksum
+  end
+  return self
 end
 
 function DataBase:is_trusted(path)

--- a/lua/yabs/init.lua
+++ b/lua/yabs/init.lua
@@ -258,8 +258,7 @@ end
 
 function Yabs:load_config_file()
   local yabs = Path:new('.yabs')
-  local db = Db:load()
-  if yabs:exists() and db:is_trusted(yabs) then
+  if yabs:exists() and Db:load():is_trusted(yabs) then
     local config = dofile(yabs.filename)
     if not config then
       utils.notify(

--- a/lua/yabs/init.lua
+++ b/lua/yabs/init.lua
@@ -1,6 +1,7 @@
 local Path = require('plenary.path')
 local Language = require('yabs.language')
 local Task = require('yabs.task')
+local Db = require('yabs.db')
 local utils = require('yabs.utils')
 local scopes = Task.scopes
 
@@ -257,7 +258,8 @@ end
 
 function Yabs:load_config_file()
   local yabs = Path:new('.yabs')
-  if yabs:exists() then
+  local db = Db:load()
+  if yabs:exists() and db:is_trusted(yabs) then
     local config = dofile(yabs.filename)
     if not config then
       utils.notify(

--- a/lua/yabs/init.lua
+++ b/lua/yabs/init.lua
@@ -283,4 +283,10 @@ function Yabs:load_config_file()
   end
 end
 
+function Yabs:reset_file_trust(path)
+  local db = Db:load()
+  db:reset(path)
+  db:save()
+end
+
 return Yabs

--- a/lua/yabs/init.lua
+++ b/lua/yabs/init.lua
@@ -283,10 +283,4 @@ function Yabs:load_config_file()
   end
 end
 
-function Yabs:reset_file_trust(path)
-  local db = Db:load()
-  db:reset(path)
-  db:save()
-end
-
 return Yabs

--- a/plugin/yabs.vim
+++ b/plugin/yabs.vim
@@ -4,5 +4,12 @@ command! -nargs=1 YabsTask
 command! YabsDefaultTask
         \ lua require("yabs"):run_default_task()
 
-command! -nargs=1 -complete=file YabsResetTrust
-        \ lua require("yabs"):reset_file_trust(<f-args>)
+" Set file as trusted (or untrusted if run as `YabsTrust!`)
+command! -bang -nargs=1 -complete=file YabsTrust
+        \ lua require("yabs.db"):load():trust(<f-args>, "<bang>" ~= "!"):save()
+
+command! -nargs=1 -complete=file YabsTrustReset
+        \ lua require("yabs.db"):load():reset(<f-args>):save()
+
+command! YabsTrustResetAll
+        \ lua require("yabs.db"):load():reset_all():save()

--- a/plugin/yabs.vim
+++ b/plugin/yabs.vim
@@ -4,7 +4,6 @@ command! -nargs=1 YabsTask
 command! YabsDefaultTask
         \ lua require("yabs"):run_default_task()
 
-" Set file as trusted (or untrusted if run as `YabsTrust!`)
 command! -bang -nargs=1 -complete=file YabsTrust
         \ lua require("yabs.db"):load():trust(<f-args>, "<bang>" ~= "!"):save()
 

--- a/plugin/yabs.vim
+++ b/plugin/yabs.vim
@@ -3,3 +3,6 @@ command! -nargs=1 YabsTask
 
 command! YabsDefaultTask
         \ lua require("yabs"):run_default_task()
+
+command! -nargs=1 -complete=file YabsResetTrust
+        \ lua require("yabs"):reset_file_trust(<f-args>)


### PR DESCRIPTION
While having `.yabs` files being Lua code (vs e.g. JSON) is convenient, running arbitrary Lua code is quite unsafe. This PR to fix this using an approach similar to [direnv](https://github.com/direnv/direnv) - require that user trusts a file before it is executed.

The "trust database" is stored in a JSON file under `vim.fn.stdpath('data') .. '/yabs.json'`. I used JSON because nvim provides built-in `vim.json.encode/decode` so there is no need for additional dependencies. When a new `.yabs` file is found or the current SHA256 checksum (also built-in `vim.fn.sha256`) of the file is different than the one in the database, user is prompted to trust the file. Answering `yes` will update the file in the database and we won't prompt until the file changes. Answering `no` will result in the file not being executed (and no prompts later), without any answer we ignore this file once and prompt again next time.

Currently all the file loading/saving is synchronous and there is no caching of the database, but I feel like there is no need for optimizing this as the database will most likely always be small and we don't execute `.yabs` files often. 