### PR TITLE
Support on_exit in 'terminal' output

### DIFF
--- a/lua/yabs/outputs/terminal.lua
+++ b/lua/yabs/outputs/terminal.lua
@@ -1,11 +1,14 @@
 local channel = nil
 local bufnr = nil
 
-local function terminal(cmd)
+local function terminal(cmd, opts)
+  opts = opts or {}
   ::retry::
   if channel == nil then
     vim.api.nvim_command('bot 10new')
-    channel = vim.fn.termopen(vim.env.SHELL)
+    local termopen_opts = {}
+    termopen_opts.on_exit = opts.on_exit or nil
+    channel = vim.fn.termopen(vim.env.SHELL, termopen_opts)
     bufnr = vim.fn.bufnr()
   end
   if not pcall(vim.fn.chansend, channel, cmd .. '\n') then


### PR DESCRIPTION
The `buffer` and `quickfix` outputs both support `on_exit` handlers, but the `terminal` output currently doesn't